### PR TITLE
Improvements of the profile page

### DIFF
--- a/django_hatstall/identities/templates/profiles/profile.html
+++ b/django_hatstall/identities/templates/profiles/profile.html
@@ -54,6 +54,38 @@
                 $('#profileBot').val('True');
               }
             });
+
+            var nPages = {{ n_pages }};
+            var currentPage = {{ current_page}};
+            var pagingControls = 'Page: ';
+            for (var i = 1; i <= nPages; i++) {
+                if ( (( i >= currentPage-2 ) && ( i <= currentPage+2 )) || ( i == nPages ) || ( i == 1 ) ) {
+                    if (i != currentPage) {
+                        pagingControls += '<button formaction type="submit" name="page" value="' + i + '" class="btn btn-info">' + i + '</button> ';
+                    } else {
+                        pagingControls += '<button formaction type="submit" name="page" value="' + i + '" class="btn" disabled>' + i + '</button> ';
+                    }
+                } else if ( (i == 1+1 || i == nPages-1) && (currentPage > 1+3 || currentPage < nPages-3) ){
+                    pagingControls += " ... "
+                }
+            }
+            pagingControls += ' ';
+            $("#customPagination").html(pagingControls);
+            // Hide default search input
+            $("#myTable_filter").attr('hidden','');
+            // Selection of the table length
+            $('#tableLength option[value="{{table_length}}"]').attr("selected",true);
+
+            $( "#shsearch" ).submit(function( event ) {
+              $('#uniqueIndentitesTable').removeAttr('hidden');
+              event.preventDefault();
+            });
+
+            if("{{show_table}}"){
+                $('#identities').removeAttr('hidden');
+                $('#uniqueIndentitesTable').removeAttr('hidden');
+            }
+
         });
     </script>
 {% endblock %}
@@ -61,7 +93,7 @@
 {% block body %}
 <h1>Profile info / <small>{{profile.profile.uuid}}</small></h1>
 <div class="row">
-    <div class="col-md-5">
+    <div class="col-md-4">
         <div class="row">
             <div class="col-lg-12">
                 <form id="profileData" action="" method="POST">{% csrf_token %}
@@ -163,7 +195,68 @@
             </div>
         </div>
     </div>
-    <div class="col-md-7">
+    <div class="col-md-4">
+        <div id="identities" hidden class="row">
+
+
+            <div class="col-lg-12">
+                <h3 class="float-left">Unique Identities</h3>
+                <button id="closeIdentities" type="button" class="close" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+                <br><br>
+                <div style="float:left; margin-bottom:4px;">
+                    <form method="POST">{% csrf_token %}
+                    Search unique identities: <input id="shsearch" name="shsearch" value="{{shsearch}}" minlength=3>
+                    </form>
+                </div>
+                <br><br>
+                <div id="uniqueIndentitesTable" hidden>
+                    <div style="float:left; margin-bottom:4px;">
+                        <form method="POST">{% csrf_token %}
+                            Show
+                            <select id="tableLength" name="table_length" value="{{table_length}}" onchange="this.form.submit()">
+                              <option value="10">10</option>
+                              <option value="25">25</option>
+                              <option value="50">50</option>
+                              <option value="100">100</option>
+                            </select>
+                            entries
+                        </form>
+                    </div>
+                    <form action="/profiles/{{profile.profile.uuid}}/merge" method="POST">{% csrf_token %}
+                        <table class="table table-striped" id="identitiesSearchTable">
+                            <thead class="thead-dark">
+                                <tr>
+                                    <th></th>
+                                    <th>Name</th>
+                                    <th>email</th>
+                                    <th>More</th>
+                                </tr>
+                            </thead>
+                            <tfoot>
+                                <tr>
+                                    <td colspan="2"><input type="submit" value="Merge" class="btn btn-success"></td>
+                                    <td colspan="3">
+                                        <div id="customPagination"></div>
+                                    </td>
+                                </tr>
+                            </tfoot>
+                            <tbody>
+                                {% for identity in unique_identities %}
+                                <tr>
+                                    <td><input type="checkbox" name="uuid" value="{{identity.profile.uuid}}"></td>
+                                    <td>{{identity.profile.name}}</td>
+                                    <td>{{identity.profile.email}}</td>
+                                    <td><a href="/profiles/{{identity.uuid}}">view</a></td>
+                                </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                    </form>
+                </div>
+            </div>
+        </div>
         <div id="organizations" hidden class="row">
             <div class="col-lg-12">
                 <h2 class="float-left">Organizations</h2>
@@ -188,7 +281,10 @@
                 </table>
             </div>
         </div>
-        <div id="identities" hidden class="row">
+    </div>
+    <div class="col-md-4">
+
+        <!--div id="identities" hidden class="row">
             <div class="col-lg-12">
                 <h2 class="float-left">Identities</h2>
                 <button id="closeIdentities" type="button" class="close" aria-label="Close">
@@ -226,7 +322,7 @@
                     </table>
                 </form>
             </div>
-        </div>
+        </div-->
     </div>
 </div>
 {% endblock %}

--- a/django_hatstall/identities/templates/profiles/profile.html
+++ b/django_hatstall/identities/templates/profiles/profile.html
@@ -20,10 +20,14 @@
 
             $('#addEnrollmentsBtn').click(function(){
                 $('#organizations').removeAttr('hidden');
+                $('#identities').attr('hidden','');
+                $('#uniqueIdentitiesCards').attr('hidden','');
             });
 
             $('#addIdentitiesBtn').click(function(){
                 $('#identities').removeAttr('hidden');
+                $('#uniqueIdentitiesCards').removeAttr('hidden');
+                $('#organizations').attr('hidden','');
             });
 
             $('#closeOrganizations').click(function(){
@@ -77,18 +81,22 @@
             $('#tableLength option[value="{{table_length}}"]').attr("selected",true);
 
             $( "#shsearch" ).submit(function( event ) {
-              $('#uniqueIndentitesTable').removeAttr('hidden');
+              $('#uniqueIdentitiesTable').removeAttr('hidden');
               event.preventDefault();
             });
 
             if("{{show_table}}"){
                 $('#identities').removeAttr('hidden');
-                $('#uniqueIndentitesTable').removeAttr('hidden');
+                $('#uniqueIdentitiesTable').removeAttr('hidden');
             }
         });
 
         // Functions based on JS events
         var showUniqueIdentity = function(uuid){
+            var cards = $('#uniqueIdentitiesCards>div')
+            for (var i = 0; i < cards.length; i++) {
+                $('#uniqueIdentitiesCards>div')[i].hidden = true;
+            }
             $('#'+ uuid).removeAttr('hidden');
         }
         var closeUniqueIdentity = function(uuid){
@@ -218,7 +226,7 @@
                     </form>
                 </div>
                 <br><br>
-                <div id="uniqueIndentitesTable" hidden>
+                <div id="uniqueIdentitiesTable" hidden>
                     <div style="float:left; margin-bottom:4px;">
                         <form method="POST">{% csrf_token %}
                             Show
@@ -289,7 +297,7 @@
             </div>
         </div>
     </div>
-    <div class="col-md-4">
+    <div class="col-md-4" id="uniqueIdentitiesCards">
         {% for uuid in unique_identities %}
             <div class="card" id="{{uuid.uuid}}" hidden>
               <div class="card-body">

--- a/django_hatstall/identities/templates/profiles/profile.html
+++ b/django_hatstall/identities/templates/profiles/profile.html
@@ -85,8 +85,15 @@
                 $('#identities').removeAttr('hidden');
                 $('#uniqueIndentitesTable').removeAttr('hidden');
             }
-
         });
+
+        // Functions based on JS events
+        var showUniqueIdentity = function(uuid){
+            $('#'+ uuid).removeAttr('hidden');
+        }
+        var closeUniqueIdentity = function(uuid){
+            $('#'+ uuid).attr('hidden','');
+        }
     </script>
 {% endblock %}
 
@@ -248,7 +255,7 @@
                                     <td><input type="checkbox" name="uuid" value="{{identity.profile.uuid}}"></td>
                                     <td>{{identity.profile.name}}</td>
                                     <td>{{identity.profile.email}}</td>
-                                    <td><a href="/profiles/{{identity.uuid}}">view</a></td>
+                                    <td><a href="javascript:showUniqueIdentity('{{identity.uuid}}');">view</a></td>
                                 </tr>
                                 {% endfor %}
                             </tbody>
@@ -283,46 +290,26 @@
         </div>
     </div>
     <div class="col-md-4">
-
-        <!--div id="identities" hidden class="row">
-            <div class="col-lg-12">
-                <h2 class="float-left">Identities</h2>
-                <button id="closeIdentities" type="button" class="close" aria-label="Close">
+        {% for uuid in unique_identities %}
+            <div class="card" id="{{uuid.uuid}}" hidden>
+              <div class="card-body">
+                <button id="close_{{uuid.uuid}}" type="button" class="close" aria-label="Close" onclick="closeUniqueIdentity('{{uuid.uuid}}')">
                     <span aria-hidden="true">&times;</span>
-                  </button>
-                <form action="/profiles/{{profile.profile.uuid}}/merge" method="POST">{% csrf_token %}
-                    <table class="table table-striped" id="identitiesTable">
-                        <thead class="thead-dark">
-                            <tr>
-                                <th></th>
-                                <th>Name</th>
-                                <th>email</th>
-                                <th>Username</th>
-                                <th>Source</th>
-                                <th>uuids.</th>
-                            </tr>
-                        </thead>
-                        <tfoot>
-                            <tr>
-                                <td colspan="6"><input type="submit" value="Merge" class="btn btn-success"></td>
-                            </tr>
-                        </tfoot>
-                        <tbody>
-                            {% for identity in identities %}
-                            <tr>
-                                <td><input type="checkbox" name="uuid" value="{{identity.uuid}}"></td>
-                                <td>{{identity.name}}</td>
-                                <td>{{identity.email}}</td>
-                                <td>{{identity.username}}</td>
-                                <td>{{identity.source}}</td>
-                                <td><a href="/profiles/{{identity.uuid}}">view</a></td>
-                            </tr>
-                            {% endfor %}
-                        </tbody>
-                    </table>
-                </form>
+                </button>
+                <h4 class="card-title">{{uuid.profile.name}}</h4>
+                  <p class="card-text"><b>Email:</b> {{uuid.profile.email}}</p>
+                  <p class="card-text"><b>Bot:</b> {{uuid.profile.is_bot}}</p>
+                  <p class="card-text"><b>Country:</b> {{uuid.profile.country.name}}</p>
+                  <p class="card-text"><b>Last Mod.:</b> {{uuid.last_modified}}</p>
+                Identities:
+                <ul class="list-group">
+                    {% for identity in uuid.identities %}
+                        <li class="list-group-item">{{identity.name}} - {{identity.email}} - {{identity.username}} - {{identity.source}}</li>
+                    {% endfor %}
+                </ul>
+              </div>
             </div>
-        </div-->
+        {% endfor %}
     </div>
 </div>
 {% endblock %}

--- a/django_hatstall/identities/templates/profiles/profile.html
+++ b/django_hatstall/identities/templates/profiles/profile.html
@@ -305,6 +305,9 @@
                     <span aria-hidden="true">&times;</span>
                 </button>
                 <h4 class="card-title">{{uuid.profile.name}}</h4>
+                  <form action="/profiles/{{profile.profile.uuid}}/merge" method="POST">{% csrf_token %}
+                    <button type="submit" name="uuid" value="{{uuid.profile.uuid}}" class="btn btn-success" style="float: right;">Merge</button>
+                  </form>
                   <p class="card-text"><b>Email:</b> {{uuid.profile.email}}</p>
                   <p class="card-text"><b>Bot:</b> {{uuid.profile.is_bot}}</p>
                   <p class="card-text"><b>Country:</b> {{uuid.profile.country.name}}</p>


### PR DESCRIPTION
This PR changes the visualization of the page:

- Now has 3 columns instead of 2
- First column shows the basic info of the profile as usual
- Second column shows the tables of adding more enrollements or unique identities (with SH pagination)
- Third column shows info about the unique identities searched in the second column, only if you click on the 'view' link