### PR TITLE
[urls] Add support for using /identities as the base path for accessing Hatstall

### DIFF
--- a/django-hatstall/django_hatstall/templates/base.html
+++ b/django-hatstall/django_hatstall/templates/base.html
@@ -44,13 +44,13 @@
 
             <ul class="navbar-nav">
                 <li class="nav-item">
-                    <a class="nav-link {% if active_page == 'profiles' %} 'active' {% endif %}" href="/hatstall/profiles">Profiles</a>
+                    <a class="nav-link {% if active_page == 'profiles' %} 'active' {% endif %}" href="profiles">Profiles</a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link {% if active_page == 'organizations' %} 'active' {% endif %}" href="/hatstall/organizations">Organizations</a>
+                    <a class="nav-link {% if active_page == 'organizations' %} 'active' {% endif %}" href="organizations">Organizations</a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link {% if active_page == 'about' %} 'active' {% endif %}" href="/hatstall/about">About</a>
+                    <a class="nav-link {% if active_page == 'about' %} 'active' {% endif %}" href="about">About</a>
                 </li>
             </ul>
 

--- a/django-hatstall/django_hatstall/urls.py
+++ b/django-hatstall/django_hatstall/urls.py
@@ -22,6 +22,8 @@ from django.views.generic import RedirectView
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('hatstall/', include('hatstall.urls')),
+    path('identities/hatstall/', include('hatstall.urls')),
     path('accounts/', include('django.contrib.auth.urls')),
+    path('identities/', RedirectView.as_view(url='/identities/hatstall')),
     path('', RedirectView.as_view(url='/hatstall'))
 ]


### PR DESCRIPTION
It is needed by nginx in order to map the identities URL for a customer to
Hatstall Django application.