### PR TITLE
Allow None country in the profile form

### DIFF
--- a/django-hatstall/hatstall/templates/profile.html
+++ b/django-hatstall/hatstall/templates/profile.html
@@ -128,6 +128,7 @@
                     <div class="form-group row">
                         <label for="profileCountry" class="col-sm-2 col-form-label"><b>Country</b></label>
                         <select id="countrySelect" name="country" type="text" disabled="true" class="col-sm-10 form-control" id=" profileCountry" value="{{profile.profile.country.code}}">
+                            <option value="">None</option>
                           {% for country in countries %}
                             <option value="{{country.code}}">{{country.name}}</option>
                           {% endfor %}


### PR DESCRIPTION
This PR adds the functionality of allows to save a profile with a None country.

This should fix https://github.com/chaoss/grimoirelab-hatstall/issues/45