### PR TITLE
Change absolute urls in href and actions to the Django right ones

### DIFF
--- a/django-hatstall/django_hatstall/templates/base.html
+++ b/django-hatstall/django_hatstall/templates/base.html
@@ -39,7 +39,7 @@
     </head>
     <body>
         <nav class="navbar navbar-expand-lg navbar-light bg-light">
-            <a href="/" class="navbar-brand">
+            <a href="{% url 'identities index' %}" class="navbar-brand">
                 <img src='{% static "hatstall/img/hatstall.svg" %}' width="30" height="30" class="d-inline-block align-top" alt="">Hatstall
             </a>
 

--- a/django-hatstall/hatstall/templates/profile.html
+++ b/django-hatstall/hatstall/templates/profile.html
@@ -154,7 +154,7 @@
                     </thead>
                     <tbody>
                         {% for enrollment in enrollments %}
-                        <form action="/hatstall/{{profile.profile.uuid}}/update_enrollment/{{enrollment.organization.name}}" method="POST">{% csrf_token %}
+                        <form action="{% url 'update identity' profile.profile.uuid enrollment.organization.name %}" method="POST">{% csrf_token %}
                             <tr>
                                 <td>{{enrollment.organization.name}}</td>
                                 <td>
@@ -170,7 +170,7 @@
                                     <button type="submit" class="btn btn-sm btn-success">Update</button>
                                 </td>
                                 <td>
-                                    <a href="/hatstall/{{profile.profile.uuid}}/unenroll_from/{{enrollment.organization.name}}_{{enrollment.start|date:'Y-m-d H:i:s'}}_{{enrollment.end|date:'Y-m-d H:i:s'}}">un-enroll</a>
+                                    <a href="{% url 'unenroll identity' profile.profile.uuid enrollment.organization.name enrollment.start|date:'Y-m-d H:i:s' enrollment.end|date:'Y-m-d H:i:s' %}">un-enroll</a>
                                 </td>
                             </tr>
                         </form>
@@ -197,7 +197,7 @@
                                 <td>{{identity.name}} - {{identity.email}} - {{identity.username}} - {{identity.source}}</td>
                                 <td>
                                     {% if profile.profile.uuid != identity.id %}
-                                    <a href="/hatstall/{{profile.profile.uuid}}/unmerge/{{identity.id}}">unmerge</a>
+                                    <a href="{% url 'unmerge identity from a profile' profile.profile.uuid identity.id %}">unmerge</a>
                                     {% endif %}
                                 </td>
                             </tr>
@@ -237,7 +237,7 @@
                             entries
                         </form>
                     </div>
-                    <form action="/hatstall/{{profile.profile.uuid}}/merge" method="POST">{% csrf_token %}
+                    <form action="{% url 'merge to profile' profile.profile.uuid %}" method="POST">{% csrf_token %}
                         <table class="table table-striped" id="identitiesSearchTable">
                             <thead class="thead-dark">
                                 <tr>
@@ -289,7 +289,7 @@
                         {% for org in orgs %}
                         <tr>
                             <td>{{org.name}}</td>
-                            <td><a href="/hatstall/{{profile.profile.uuid}}/enroll_in/{{org.name}}">enroll</a></td>
+                            <td><a href="{% url 'enroll identity' profile.profile.uuid org.name %}">enroll</a></td>
                         </tr>
                         {% endfor %}
                     </tbody>
@@ -305,7 +305,7 @@
                     <span aria-hidden="true">&times;</span>
                 </button>
                 <h4 class="card-title">{{uuid.profile.name}}</h4>
-                  <form action="/hatstall/{{profile.profile.uuid}}/merge" method="POST">{% csrf_token %}
+                  <form action="{% url 'merge to profile' profile.profile.uuid %}" method="POST">{% csrf_token %}
                     <button type="submit" name="uuid" value="{{uuid.profile.uuid}}" class="btn btn-success" style="float: right;">Merge</button>
                   </form>
                   <p class="card-text"><b>Email:</b> {{uuid.profile.email}}</p>

--- a/django-hatstall/hatstall/urls.py
+++ b/django-hatstall/hatstall/urls.py
@@ -16,7 +16,8 @@ urlpatterns = [
             views.update_enrollment, name='update identity'),
     re_path(r'^(?P<identity_id>[0-f]+)/enroll_in/(?P<organization>[0-9A-Za-z\w|\W]+)$',
             views.enroll_to_profile, name='enroll identity'),
-    re_path(r'^(?P<identity_id>[0-f]+)/unenroll_from/(?P<organization_info>[0-9A-Za-z\w|\W]+)$',
+    re_path(r'^(?P<identity_id>[0-f]+)/unenroll_from/(?P<organization_info>[0-9A-Za-z\w|\W]+)/ \
+            (?P<enrollment_start_date>[0-9A-Za-z\w|\W]+)/(?P<enrollment_end_date>[0-9A-Za-z\w|\W]+)$',
             views.unenroll_profile, name='unenroll identity'),
     re_path(r'^(?P<identity_id>[0-f]+)/merge$', views.merge_to_profile, name='merge to profile'),
     re_path(r'^(?P<profile_uuid>[0-f]+)/unmerge/(?P<identity_id>[0-f]+)$', views.unmerge, name='unmerge identity from a profile'),

--- a/django-hatstall/hatstall/views.py
+++ b/django-hatstall/hatstall/views.py
@@ -1,4 +1,5 @@
 import configparser
+import datetime
 import math
 import os
 
@@ -143,7 +144,7 @@ def update_enrollment(request, identity_id, organization):
 
 
 @login_required
-def unenroll_profile(request, identity_id, organization_info):
+def unenroll_profile(request, identity_id, organization_info, enrollment_start_date, enrollment_end_date):
     """
     Un-enroll a profile uuid from an organization
     """
@@ -153,10 +154,9 @@ def unenroll_profile(request, identity_id, organization_info):
     if request.method == 'POST':
         return redirect('/hatstall/' + identity_id)
     db = sortinghat_db_conn()
-    org_name = organization_info.split('_')[0]
-    org_start = parser.parse(organization_info.split('_')[1])
-    org_end = parser.parse(organization_info.split('_')[2])
-    sortinghat.api.delete_enrollment(db, identity_id, org_name, org_start, org_end)
+    sortinghat.api.delete_enrollment(db, identity_id, organization_info,
+                                     datetime.datetime.strptime(enrollment_start_date, '%Y-%m-%d %H:%M:%S'),
+                                     datetime.datetime.strptime(enrollment_end_date, '%Y-%m-%d %H:%M:%S'))
     return redirect('/hatstall/' + identity_id)
 
 


### PR DESCRIPTION
This PR contains:

- I changed all the urls that contains absolute paths to the urls that Django uses.
- I also changed one resources, the one that unenroll organizations because it was bad formed, concatenating strings in the url. I just extend the resource adding two more levels in order to add and parse like Django urls dispatcher [1] defines.


More info about Django URLs:
[1] https://docs.djangoproject.com/en/1.10/topics/http/urls/