### PR TITLE
Show error when an uuid does not belong to a profile

### DIFF
--- a/django-hatstall/hatstall/templates/search_identities.html
+++ b/django-hatstall/hatstall/templates/search_identities.html
@@ -7,7 +7,7 @@
 <div class="container" style="margin-top: 10%;">
   <h1 style="text-align: center; font-weight: bold">Search identities <i class="fa fa-search icon"></i></h1>
   <br>
-  <form action="list" method="POST">{% csrf_token %}
+  <form action="{% url 'identities list' %}" method="POST">{% csrf_token %}
     <div class="input-group">
         <input class="form-control" id="shsearch" name="shsearch" minlength=3 placeholder="Search identities...">
         <span class="input-group-btn">

--- a/django-hatstall/hatstall/views.py
+++ b/django-hatstall/hatstall/views.py
@@ -388,6 +388,12 @@ def render_profile(db, profile_uuid, request, err=None):
     with db.connect() as session:
         profile_info = session.query(UniqueIdentity). \
             filter(UniqueIdentity.uuid == profile_uuid).first()
+        if not profile_info:
+            context = {
+                "err": "uuid {} does not belong to a profile".format(profile_uuid)
+            }
+            template = loader.get_template('search_identities.html')
+            return template.render(context, request)
         for enrollment in profile_info.enrollments:
             profile_enrollments.append(enrollment)
         countries = sortinghat.api.countries(db)


### PR DESCRIPTION
By default, if the user enters into an url of an uuid that does not belong to a profile, hatstall returns an error that chains a 500 error in the server. This feature fixes it rendering the "search identities form" with an error notifying the user.

This PR fixes #67 