### PR TITLE
Redirect to the profile where the others profiles are merged

### DIFF
--- a/django-hatstall/hatstall/views.py
+++ b/django-hatstall/hatstall/views.py
@@ -132,7 +132,7 @@ def update_enrollment(request, identity_id, organization):
     if not Conf.check_conf():
         return redirect('shdb')
     if request.method != 'POST':
-        return redirect('profiles/list')
+        return redirect('identities list')
     db = sortinghat_db_conn()
     old_start_date = parser.parse(request.POST.get('old_start_date'))
     old_end_date = parser.parse(request.POST.get('old_end_date'))
@@ -140,7 +140,7 @@ def update_enrollment(request, identity_id, organization):
     end_date = parser.parse(request.POST.get('end_date'))
     sortinghat.api.delete_enrollment(db, identity_id, organization, old_start_date, old_end_date)
     sortinghat.api.add_enrollment(db, identity_id, organization, start_date, end_date)
-    return redirect('/identities/hatstall/' + identity_id)
+    return redirect('show identity', identity_id=identity_id)
 
 
 @login_required
@@ -152,12 +152,12 @@ def unenroll_profile(request, identity_id, organization_info, enrollment_start_d
     if not Conf.check_conf():
         return redirect('shdb')
     if request.method == 'POST':
-        return redirect('/identities/hatstall/' + identity_id)
+        return redirect('show identity', identity_id=identity_id)
     db = sortinghat_db_conn()
     sortinghat.api.delete_enrollment(db, identity_id, organization_info,
                                      datetime.datetime.strptime(enrollment_start_date, '%Y-%m-%d %H:%M:%S'),
                                      datetime.datetime.strptime(enrollment_end_date, '%Y-%m-%d %H:%M:%S'))
-    return redirect('/identities/hatstall/' + identity_id)
+    return redirect('show identity', identity_id=identity_id)
 
 
 @login_required
@@ -169,14 +169,14 @@ def enroll_to_profile(request, identity_id, organization):
     if not Conf.check_conf():
         return redirect('shdb')
     if request.method == 'POST':
-        return redirect('/identities/hatstall/' + identity_id)
+        return redirect('show identity', identity_id=identity_id)
     db = sortinghat_db_conn()
     try:
         sortinghat.api.add_enrollment(db, identity_id, organization)
         err = None
     except sortinghat.exceptions.AlreadyExistsError as error:
         err = error
-    return redirect('/identities/hatstall/' + identity_id)
+    return redirect('show identity', identity_id=identity_id)
 
 
 @login_required
@@ -190,7 +190,7 @@ def merge_profiles(request):
 
     if request.method == 'POST':
         last_uuid, err = merge(request.POST.getlist('uuid'))
-    return redirect('/identities/hatstall/' + last_uuid)
+    return redirect('show identity', identity_id=last_uuid)
 
 
 @login_required
@@ -202,11 +202,11 @@ def merge_to_profile(request, identity_id):
     if not Conf.check_conf():
         return redirect('shdb')
     if request.method != 'POST':
-        return redirect('/identities/hatstall/' + identity_id)
+        return redirect('show identity', identity_id=identity_id)
     uuids = request.POST.getlist('uuid')
     uuids.append(identity_id)
     last_uuid, err = merge(uuids)
-    return redirect('/identities/hatstall/' + identity_id)
+    return redirect('show identity', identity_id=identity_id)
 
 
 @login_required
@@ -218,7 +218,7 @@ def unmerge(request, profile_uuid, identity_id):
     if not Conf.check_conf():
         return redirect('shdb')
     if request.method != 'GET':
-        return redirect('/identities/hatstall/' + profile_uuid)
+        return redirect('show identity', identity_id=profile_uuid)
     db = sortinghat_db_conn()
     sortinghat.api.move_identity(db, identity_id, identity_id)
     with db.connect() as session:
@@ -227,7 +227,7 @@ def unmerge(request, profile_uuid, identity_id):
         uid_profile_email = edit_identity.email
         sortinghat.api.edit_profile(db, identity_id, name=uid_profile_name, email=uid_profile_email)
     session.expunge_all()
-    return redirect('/identities/hatstall/' + profile_uuid)
+    return redirect('show identity', identity_id=profile_uuid)
 
 
 @login_required

--- a/django-hatstall/hatstall/views.py
+++ b/django-hatstall/hatstall/views.py
@@ -189,8 +189,8 @@ def merge_profiles(request):
     """
 
     if request.method == 'POST':
-        err = merge(request.POST.getlist('uuid'))
-    return redirect('identities list')
+        last_uuid, err = merge(request.POST.getlist('uuid'))
+    return redirect('/identities/hatstall/' + last_uuid)
 
 
 @login_required
@@ -205,7 +205,7 @@ def merge_to_profile(request, identity_id):
         return redirect('/identities/hatstall/' + identity_id)
     uuids = request.POST.getlist('uuid')
     uuids.append(identity_id)
-    err = merge(uuids)
+    last_uuid, err = merge(uuids)
     return redirect('/identities/hatstall/' + identity_id)
 
 
@@ -303,9 +303,11 @@ def merge(uuids):
         for uuid in uuids[:-1]:
             sortinghat.api.merge_unique_identities(db, uuid, uuids[-1])
             err = None
+        last_uuid = uuids[-1]
     else:
         err = "You need at least 2 profiles to merge them"
-    return err
+        last_uuid = None
+    return last_uuid, err
 
 
 def sortinghat_db_conn():


### PR DESCRIPTION
By default, when a user merges profiles from the main table, the user is redirected to the search form, losing the info and forcing to search the profile again. This commit change that, redirecting to the "final profile" where the others profiles are merged.

This PR is related to #71 