### PR TITLE
[setup] Fix format type for long description of package

### DIFF
--- a/django-hatstall/setup.py
+++ b/django-hatstall/setup.py
@@ -1,8 +1,12 @@
+import codecs
 import os
 from setuptools import setup
 
-with open(os.path.join(os.path.dirname(__file__), 'README.rst')) as readme:
-    README = readme.read()
+here = os.path.abspath(os.path.dirname(__file__))
+readme_md = os.path.join(here, 'README.md')
+
+with codecs.open(readme_md, encoding='utf-8') as f:
+    long_description = f.read()
 
 # allow setup.py to be run from any path
 os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
@@ -14,7 +18,8 @@ setup(
     include_package_data=True,
     license='GPLv3',
     description='A Django app to manage identities in Sorting Hat.',
-    long_description=README,
+    long_description=long_description,
+    long_description_content_type='text/markdown',
     url='https://github.com/chaoss/grimoirelab-hatstall',
     author='Bitergia',
     author_email='acs@bitergia.com',


### PR DESCRIPTION
Pypi requires that the format of the long description for a package is detailed in the variable `long_description_content_type`, in setup.py. Since it now supports Markdown, the conversion to
reST is not needed anymore.