### PR TITLE
[hatstall] Support check/uncheck all options in checkbox tables

### DIFF
--- a/django-hatstall/hatstall/templates/profile.html
+++ b/django-hatstall/hatstall/templates/profile.html
@@ -90,6 +90,11 @@
                 $('#identities').removeAttr('hidden');
                 $('#uniqueIdentitiesTable').removeAttr('hidden');
             }
+
+            // Control checking and unchecking all checkboxes
+            $("#selectAll").change(function() {
+                $('.checkboxRow:checkbox').prop('checked', this.checked);
+            });
         });
 
         // Functions based on JS events
@@ -241,7 +246,7 @@
                         <table class="table table-striped" id="identitiesSearchTable">
                             <thead class="thead-dark">
                                 <tr>
-                                    <th></th>
+                                    <th><input id="selectAll" type="checkbox"></th>
                                     <th>Name</th>
                                     <th>email</th>
                                     <th>More</th>
@@ -259,7 +264,7 @@
                                 {% for identity in unique_identities %}
                                 <tr>
                                     {% if identity.profile.uuid != profile.profile.uuid %}
-                                        <td><input type="checkbox" name="uuid" value="{{identity.profile.uuid}}"></td>
+                                        <td><input class="checkboxRow" type="checkbox" name="uuid" value="{{identity.profile.uuid}}"></td>
                                         <td>{{identity.profile.name}}</td>
                                         <td>{{identity.profile.email}}</td>
                                         <td><a href="javascript:showUniqueIdentity('{{identity.uuid}}');">view</a></td>

--- a/django-hatstall/hatstall/templates/profiles.html
+++ b/django-hatstall/hatstall/templates/profiles.html
@@ -10,6 +10,10 @@
     <script type="text/javascript">
         $(document).ready(function(){
             $('#myTable').DataTable({
+                "columnDefs": [{
+                    "targets": 'no-sort',
+                    "orderable": false
+                }],
                 "lengthChange": false,
                 "paging": false
             });
@@ -35,6 +39,10 @@
             // Selection of the table length
             $('#tableLength option[value="{{table_length}}"]').attr("selected",true);
 
+            // Control checking and unchecking all checkboxes
+            $("#selectAll").change(function() {
+                $('.checkboxRow:checkbox').prop('checked', this.checked);
+            });
         });
     </script>
 {% endblock %}
@@ -64,7 +72,7 @@
     <table class="table table-striped" id="myTable">
         <thead class="thead-dark">
             <tr>
-                <th></th>
+                <th class="no-sort"><input id="selectAll" type="checkbox"></th>
                 <th>Name</th>
                 <th>email</th>
                 <th>Enrollments</th>
@@ -91,7 +99,7 @@
             {% if uid.profile %}
             <tr>
                 <td>
-                    <input type="checkbox" name="uuid" value="{{uid.profile.uuid}}">
+                    <input class="checkboxRow" type="checkbox" name="uuid" value="{{uid.profile.uuid}}">
                 </td>
                 <td><a href="{{uid.profile.uuid}}">{{uid.profile.name|blank_name}}</a></td>
                 <td>{{uid.profile.email}}</td>


### PR DESCRIPTION
This option is included in all the tables containing _checkboxes_:
* The table showing the profiles (UUIDs) when performing a search.
* The table inside a single profile allowing to merge UUIDs.

Limitations: the select/un-select is applied to table rows for the current page and it is not supported for rows in different pages.

This PR aims to solve issue https://github.com/chaoss/grimoirelab-hatstall/issues/91.

Edit: I'm including some screenshots.

![Screenshot from 2019-12-27 14-00-53](https://user-images.githubusercontent.com/9032790/71518087-59d9f480-28b1-11ea-9c0e-38de2d41f317.png)

![Screenshot from 2019-12-27 13-59-46](https://user-images.githubusercontent.com/9032790/71518067-3adb6280-28b1-11ea-9a55-7054cb8426a3.png)
