### PR TITLE
Update files to create the django-hatstall pip package

### DIFF
--- a/django-hatstall/MANIFEST.in
+++ b/django-hatstall/MANIFEST.in
@@ -2,4 +2,5 @@ include LICENSE
 include README.rst
 recursive-include hatstall/static *
 recursive-include hatstall/templates *
+recursive-include hatstall/templatetags *
 recursive-include docs *

--- a/django-hatstall/README.rst
+++ b/django-hatstall/README.rst
@@ -5,7 +5,7 @@ Hatstall
 Hatstall is a Django app to manage the identities in Sorting Hat. You can
 edit, list, merge, unmerge and enroll the identities in SortingHat.
 
-Detailed documentation is in the "docs" directory.
+Detailed documentation is at https://github.com/chaoss/grimoirelab-hatstall
 
 Quick start
 -----------

--- a/django-hatstall/setup.py
+++ b/django-hatstall/setup.py
@@ -3,7 +3,7 @@ import os
 from setuptools import setup
 
 here = os.path.abspath(os.path.dirname(__file__))
-readme_md = os.path.join(here, 'README.md')
+readme_md = os.path.join(here, 'README.rst')
 
 with codecs.open(readme_md, encoding='utf-8') as f:
     long_description = f.read()
@@ -19,7 +19,7 @@ setup(
     license='GPLv3',
     description='A Django app to manage identities in Sorting Hat.',
     long_description=long_description,
-    long_description_content_type='text/markdown',
+    long_description_content_type='text/x-rst',
     url='https://github.com/chaoss/grimoirelab-hatstall',
     author='Bitergia',
     author_email='acs@bitergia.com',


### PR DESCRIPTION
This commit fixes a bug that did not allow to build the package because
README.md does not exist and include in MANIFEST.in `templatetags`

Error related to README.md:
```
    ERROR: Command errored out with exit status 1:
     command: /usr/local/bin/python -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-req-build-q383dvie/setup.py'"'"'; __file__='"'"'/tmp/pip-req-build-q383dvie/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-req-build-q383dvie/pip-egg-info
         cwd: /tmp/pip-req-build-q383dvie/
    Complete output (7 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-req-build-q383dvie/setup.py", line 8, in <module>
        with codecs.open(readme_md, encoding='utf-8') as f:
      File "/usr/local/lib/python3.6/codecs.py", line 897, in open
        file = builtins.open(filename, mode, buffering)
    FileNotFoundError: [Errno 2] No such file or directory: '/tmp/pip-req-build-q383dvie/README.md'
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
```