### PR TITLE
[hatstall] Fix method editing organization domain

### DIFF
--- a/django-hatstall/hatstall/views.py
+++ b/django-hatstall/hatstall/views.py
@@ -284,7 +284,8 @@ def edit_organization(request, organization):
     if request.method == 'POST':
         try:
             match_orgs = sortinghat.api.registry(db, organization)
-            org_edit_form = match_orgs[0] if match_orgs else None  # Get first result
+            org_edit_form = [org for org in match_orgs if org.name == organization]
+            org_edit_form = org_edit_form[0] if org_edit_form else None  # Get first result
         except sortinghat.exceptions.NotFoundError as error:
             err = error
     # Get data to render view
@@ -339,7 +340,8 @@ def add_domain(request, organization):
             err = error
     # Get data to render view
     match_orgs = sortinghat.api.registry(db, organization)
-    org_edit_form = match_orgs[0] if match_orgs else None  # Get first result
+    org_edit_form = [org for org in match_orgs if org.name == organization]
+    org_edit_form = org_edit_form[0] if org_edit_form else None  # Get first result
     doms_edit_form = [dom.domain for dom in org_edit_form.domains]
     orgs = sortinghat.api.registry(db)
     context = {
@@ -367,7 +369,8 @@ def delete_domain(request, organization, domain):
             err = error
     # Get data to render view
     match_orgs = sortinghat.api.registry(db, organization)
-    org_edit_form = match_orgs[0] if match_orgs else None  # Get first result
+    org_edit_form = [org for org in match_orgs if org.name == organization]
+    org_edit_form = org_edit_form[0] if org_edit_form else None  # Get first result
     doms_edit_form = [dom.domain for dom in org_edit_form.domains]
     orgs = sortinghat.api.registry(db)
     context = {


### PR DESCRIPTION
This code fixes when the method `sortinghat.api.registry` returns
several organizations and the first one is not the correct one.

Now, the filter results are processed to check if the target
organization matches with any of the results.

This change has been applied to the following methods:
 - `edit_organization`
 - `add_domain`
 - `delete_domain`

NOTE: This PR solves issue https://github.com/chaoss/grimoirelab-hatstall/issues/97.

Signed-off-by: Quan Zhou <quan@bitergia.com>

Related to https://github.com/chaoss/grimoirelab-hatstall/issues/97