### PR TITLE
Support assign same organization in different time frames

### DIFF
--- a/django-hatstall/hatstall/templates/profile.html
+++ b/django-hatstall/hatstall/templates/profile.html
@@ -175,7 +175,9 @@
                                     <button type="submit" class="btn btn-sm btn-success">Update</button>
                                 </td>
                                 <td>
-                                    <a href="{% url 'unenroll identity' profile.profile.uuid enrollment.organization.name enrollment.start|date:'Y-m-d H:i:s' enrollment.end|date:'Y-m-d H:i:s' %}">un-enroll</a>
+                                    <a class="btn btn-sm btn-danger" href="{% url 'unenroll identity' profile.profile.uuid enrollment.organization.name enrollment.start|date:'Y-m-d H:i:s' enrollment.end|date:'Y-m-d H:i:s' %}">
+                                       Un-enroll
+                                    </a>
                                 </td>
                             </tr>
                         </form>
@@ -294,7 +296,11 @@
                         {% for org in orgs %}
                         <tr>
                             <td>{{org.name}}</td>
-                            <td><a href="{% url 'enroll identity' profile.profile.uuid org.name %}">enroll</a></td>
+                            <td>
+                                <a class="btn btn-sm btn-success" href="{% url 'enroll identity' profile.profile.uuid org.name %}">
+                                    Enroll
+                                </a>
+                            </td>
                         </tr>
                         {% endfor %}
                     </tbody>

--- a/django-hatstall/hatstall/views.py
+++ b/django-hatstall/hatstall/views.py
@@ -8,6 +8,8 @@ from django.contrib.auth.decorators import login_required
 
 import sortinghat.api
 
+from sortinghat.cmd.enroll import Enroll
+
 from sortinghat.db.database import Database
 from sortinghat.db.model import UniqueIdentity
 from sortinghat.db.model import Identity
@@ -41,6 +43,7 @@ class Conf():
     shdb_pass = None
     shdb_name = None
     shdb_host = None
+    shdb_port = "3306"  # Default port
     sh_db_cfg = "shdb.cfg"  # Default config file
 
     @staticmethod
@@ -124,22 +127,32 @@ def identity(request, identity_id):
 @login_required
 def update_enrollment(request, identity_id, organization):
     """
-    Update profile enrollment dates
-    It first removes old enrollment
-    and creates a new one (base on the new dates)
+    Update the enrollment from a profile updating dates
+    using `Enroll` command, merging overlapping dates.
     """
-    err = None
     if not Conf.check_conf():
         return redirect('shdb')
     if request.method != 'POST':
         return redirect('identities list')
-    db = sortinghat_db_conn()
-    old_start_date = parser.parse(request.POST.get('old_start_date'))
-    old_end_date = parser.parse(request.POST.get('old_end_date'))
+
+    db_args = {
+        "user": Conf.shdb_user,
+        "password": Conf.shdb_pass,
+        "database": Conf.shdb_name,
+        "host": Conf.shdb_host,
+        "port": Conf.shdb_port
+    }
+
     start_date = parser.parse(request.POST.get('start_date'))
     end_date = parser.parse(request.POST.get('end_date'))
-    sortinghat.api.delete_enrollment(db, identity_id, organization, old_start_date, old_end_date)
-    sortinghat.api.add_enrollment(db, identity_id, organization, start_date, end_date)
+
+    enroll_cmd = Enroll(**db_args)
+    enroll_cmd.enroll(identity_id,
+                      organization,
+                      from_date=start_date,
+                      to_date=end_date,
+                      merge=True)
+
     return redirect('show identity', identity_id=identity_id)
 
 

--- a/django-hatstall/hatstall/views.py
+++ b/django-hatstall/hatstall/views.py
@@ -540,6 +540,9 @@ def render_profile(db, profile_uuid, request, err=None):
             return template.render(context, request)
         for enrollment in profile_info.enrollments:
             profile_enrollments.append(enrollment)
+        profile_enrollments.sort(key=lambda x: x.start,
+                                 reverse=True)
+
         countries = sortinghat.api.countries(db)
         session.expunge_all()
 
@@ -584,7 +587,7 @@ def render_profile(db, profile_uuid, request, err=None):
     context = {
         "profile": profile_info.to_dict(), "orgs": orgs, "unique_identities": unique_identities, "n_pages": n_pages,
         "current_page": current_page_profile, "shsearch": shsearch_profile, "table_length": table_length_profile,
-        "show_table": show_table, "enrollments": profile_info.enrollments, "countries": countries, "err": err
+        "show_table": show_table, "enrollments": profile_enrollments, "countries": countries, "err": err
     }
     template = loader.get_template('profile.html')
     return template.render(context, request)


### PR DESCRIPTION
This PR aims to fix issue https://github.com/chaoss/grimoirelab-hatstall/issues/108. 

## Context

When an enrollment is first added, Hatstall uses the default min and max dates (date range `1900-01-01` to `2100-01-01`. This means when an enrollment is set to be updated, is deleted in Sortinghat deleting also other enrollments for the given organization with other date ranges (if any), which are always included within the default one. This is why different enrollments for the same organization was not supported.

For instance, let's build this scenario on Hatstall from scratch:
* Add `Org 1`.
* New enrollment `enr1` to `Org 1`. This is added with default dates, from `1900-01-01` to `2100-01-01`.
* Enrollment `enr1` start date is updated to `2019-01-01`.
* New enrollment `enr2` to `Org 1`. This is also added with default dates, from `1900-01-01` to `2100-01-01`.
* Enrollment `enr2` end date is set to `2012-05-30`.

Then, the `update_enrollment` method (Hatstall) first deletes the enrollment `enr2` with the old dates (1900 - 2100), so it also deletes `enr1`, as its date range (2019 - 2100) is under the bigger one.

After this change, adding different time frames for a given organization is supported.

## Proposed solution

Adding different time frames for a given organization is supported by using the `Enroll` SortingHat command, with the `merge` option set to `True`. This means overlapping date ranges for a given organization will be merged.

To initialize the object from this command's class is necessary to provide the database connection parameters, which are taken from the `Conf` class in Hatstall. The parameter `port` has been added to this class with a default value, similar to other methods using the `Database` class which has the same default port value.

## Additional changes
* Both `Enroll` and `Un-enroll` links have been changed to buttons, aligned with the rest of the actions in that view.
* Now enrollments are ordered by `start` date in the profile view. Before this change, results could appear in a different order each time the page was rendered.