### PR TITLE
Update docker image to Debian 10 (Buster)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,8 @@
-# Copyright (C) 2018 Bitergia
+# Copyright (C) 2018-2021 Bitergia
 # GPLv3 License
 
-FROM debian:stretch-slim
-MAINTAINER Alvaro del Castillo <acs@bitergia.com>
+FROM debian:buster-slim
+MAINTAINER Santiago Dueñas <sduenas@bitergia.com>
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV DEPLOY_USER grimoirelab


### PR DESCRIPTION
The current version of the docker image uses Debian Stretch.
The end of life of this version terminated in Jun 2020.

This patch updates the image to Debian Buster, which also includes
Python > 3.6. Python 3.5 also ended its life last year.

Maintainer of the image was also updated.

Signed-off-by: Santiago Dueñas <sduenas@bitergia.com>