### PR TITLE
Install MariaDB client in docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && \
         bash locales \
         gcc \
         git git-core \
-        mysql-client \
+        mariadb-client \
         python3 \
         python3-pip \
         python3-venv \


### PR DESCRIPTION
The package `mysql-client` is no longer available in Debian by default but it can be
replaced by `mariadb-client`.

Signed-off-by: Santiago Dueñas <sduenas@bitergia.com>