### PR TITLE
Remove unnecessary dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,6 @@ According to [Harry Potter Wiki](http://harrypotter.wikia.com/wiki/Hatstall) **H
 ## Requirements
 
 * Django
-* grimoire-elk
-* grimoirelab-toolkit
 * sortinghat
 
 ## Installation

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -40,20 +40,14 @@ ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 ENV LANG C.UTF-8
 
-# Install pip packages needed
-RUN pip3 install django
-RUN pip3 install python-dateutil
-RUN pip3 install pandas==0.18.1
-RUN pip3 install setuptools
-RUN pip3 install sortinghat
-
 ADD stage ${DEPLOY_USER_DIR}/stage
 RUN chmod 755 ${DEPLOY_USER_DIR}/stage
 
 USER ${DEPLOY_USER}
 WORKDIR ${DEPLOY_USER_DIR}
 
-# Install hatstall
+# Install hatstall and dependencies
 RUN git clone https://github.com/chaoss/grimoirelab-hatstall.git
+RUN pip3 install -r grimoirelab-hatstall/requirements.txt
 
 CMD ${DEPLOY_USER_DIR}/stage

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,2 @@
 Django
-grimoire-elk
-grimoirelab-toolkit
 sortinghat


### PR DESCRIPTION
ELK and other GrimoireLab tools were listed as dependencies.
These are not really needed and have been removed.

Additionally, some changes were made in the docker files
to install only the dependencies set in 'requirements.txt'
file.

Signed-off-by: Santiago Dueñas <sduenas@bitergia.com>