### PR TITLE
[docker] Install Python dependences globally

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -48,6 +48,6 @@ WORKDIR ${DEPLOY_USER_DIR}
 
 # Install hatstall and dependencies
 RUN git clone https://github.com/chaoss/grimoirelab-hatstall.git
-RUN pip3 install -r grimoirelab-hatstall/requirements.txt
+RUN sudo pip3 install -r grimoirelab-hatstall/requirements.txt
 
 CMD ${DEPLOY_USER_DIR}/stage


### PR DESCRIPTION
Dependencies were installed locally and Apache server
runs with www-date. Therefore, there was some errors
saying Apache could not find Django packages.

This was solved installing these dependencies in the system.

Signed-off-by: Santiago Dueñas <sduenas@bitergia.com>