### PR TITLE
Fix link to grimoirelab-hatstall in About page

### DIFF
--- a/django-hatstall/hatstall/templates/about.html
+++ b/django-hatstall/hatstall/templates/about.html
@@ -19,6 +19,6 @@
   preference into consideration in order to break such a tie.</p>
   <footer class="blockquote-footer"><a href="http://harrypotter.wikia.com/wiki/Hatstall"><cite title="Source Title">Harry Potter Wiki</cite></a></footer>
 </blockquote>
-<p>Source code, issues, etc. to <a href="https://github.com/acs/django-hatstall">me</a>!</p>
+<p>Source code, issues, etc. to <a href="https://github.com/chaoss/grimoirelab-hatstall">grimoirelab-hatstall</a>!</p>
 {% endblock %}
 {% endwith  %}


### PR DESCRIPTION
Fix link to HatStall repo in the "About" page

Signed-off-by: Jose Manrique Lopez de la Fuente <jsmanrique@bitergia.com>